### PR TITLE
Made it possible to load GIF images into a TK window from bytes

### DIFF
--- a/gophersnake.py
+++ b/gophersnake.py
@@ -29,6 +29,7 @@ import webbrowser
 import socket
 from threading import Thread
 import sys
+from io import BytesIO
 
 if sys.version_info.major >= 3:
 	from urllib.parse import urlparse
@@ -345,8 +346,8 @@ def handle_entry(entry):
 	elif entry[0] == "g":
 		# TO DO: open GIF files in own window.
 		def save_fn():
-			#load_with_status(entry, open_image_viewer)
-			save_with_status(entry[2], entry[3], int(entry[4]))
+			load_with_status(entry, open_image_viewer)
+			#save_with_status(entry[2], entry[3], int(entry[4]))
 		save_op = Thread(None, save_fn)
 		save_op.start()
 	elif entry[0] == "h":
@@ -619,7 +620,8 @@ def open_text_viewer(url, data):
 # Broken as of 2016-08-29
 def open_image_viewer(url, bdata):
 	global img
-	img = PhotoImage(data=bdata)
+	stream = BytesIO(bdata)
+	img = PhotoImage(data=stream.read())
 	
 	window = Toplevel(top)
 	window.title("Gophersnake image viewer")


### PR DESCRIPTION
I tried to change as little of the existing code as possible. As such I uncommented `load_with_status` and  commented `save_with_status`, but did not change any function/variable names.

I imagine you will want to provide the ability for the image to be saved OR loaded. My adjustment allows for the image to be loaded. Further work will need to be done to make a choice for alternate actions.

I tested the result in both Python 2.7.15rc1 and 3.6.6. GIF images loaded the same in both. Animations do not work, but a still GIF loads either way (either an existing single frame GIF, or just the first frame of an animated GIF). The images were a little slow to load, but stick with it and it will pop up.